### PR TITLE
#46 Added UI fields to update a clients name, desc and icon url 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,13 +11,6 @@ pipeline {
     GH_TOKEN = credentials('github-api')
     SBT_OPS = '-DMONGO_URI=mongodb://jenkins-mongo:27017 -Dsbt.global.base=.sbt -Dsbt.boot.directory=.sbt -Dsbt.ivy.home=.ivy2 -Dlocal=false'
   }
-  parameters {
-    choice(
-      name: 'VersionType',
-      choices: "minor\nmajor\nhotfix",
-      description: 'What type of version to build.'
-    )
-  }
   options {
     ansiColor('xterm')
   }
@@ -32,24 +25,6 @@ pipeline {
     stage("Publish coverage report"){
       steps{
         step([$class: 'ScoveragePublisher', reportDir: './target/scala-2.13/scoverage-report', reportFile: 'scoverage.xml'])
-      }
-    }
-    stage('Version project') {
-      when {
-        branch 'master'
-      }
-      steps {
-        script {
-          build job: 'operations/create-a-release', parameters: [string(name: 'Project', value: 'gatekeeper'), string(name: 'Type', value: params.VersionType)]
-          gitVersion = sh(
-            script: '''
-              JQ=./jq
-              curl https://stedolan.github.io/jq/download/linux64/jq > $JQ && chmod +x $JQ
-              curl -H "Accept: application/vnd.github.manifold-preview" -H 'Authorization: token '$GH_TOKEN'' -s 'https://api.github.com/repos/cjww-development/gatekeeper/releases/latest' | ./jq -r '.tag_name'
-            ''',
-            returnStdout: true
-          ).trim()
-        }
       }
     }
   }

--- a/app/controllers/ui/ClientController.scala
+++ b/app/controllers/ui/ClientController.scala
@@ -197,4 +197,15 @@ trait ClientController extends BaseController with I18NSupportLowPriorityImplici
       _ => Redirect(routes.ClientController.getClientDetails(appId))
     }
   }
+
+  def updateBasicDetails(appId: String): Action[AnyContent] = authenticatedOrgUser { implicit req => orgUserId =>
+    val body = req.body.asFormUrlEncoded.getOrElse(Map())
+    val name = body.getOrElse("name", Seq("")).head
+    val desc = body.getOrElse("desc", Seq("")).head
+    val iconUrl = body.get("icon-url").filter(_.head != "").map(_.head)
+
+    clientOrchestrator.updateBasicDetails(appId, orgUserId, name, desc, iconUrl) map {
+      _ => Redirect(routes.ClientController.getClientDetails(appId))
+    }
+  }
 }

--- a/app/orchestrators/ClientOrchestrator.scala
+++ b/app/orchestrators/ClientOrchestrator.scala
@@ -33,6 +33,7 @@ case object UpdatedFailed extends AppUpdateResponse
 case object FlowsUpdated extends AppUpdateResponse
 case object ExpiryUpdated extends AppUpdateResponse
 case object UrlsUpdated extends AppUpdateResponse
+case object BasicsUpdates extends AppUpdateResponse
 
 class DefaultClientOrchestrator @Inject()(val clientService: ClientService,
                                           val userService: UserService,
@@ -175,6 +176,17 @@ trait ClientOrchestrator {
         UrlsUpdated
       case MongoFailedUpdate =>
         logger.warn(s"[updateRedirects] - Failed to update home url and redirect url for app $appId belonging to org user $orgUserId")
+        UpdatedFailed
+    }
+  }
+
+  def updateBasicDetails(appId: String, orgUserId: String, name: String, desc: String, iconUrl: Option[String])(implicit ec: ExC): Future[AppUpdateResponse] = {
+    clientService.updateBasicDetails(orgUserId, appId, name, desc, iconUrl) map {
+      case MongoSuccessUpdate =>
+        logger.info(s"[updateBasicDetails] - Updated the basics for app $appId belonging to org user $orgUserId")
+        BasicsUpdates
+      case MongoFailedUpdate =>
+        logger.warn(s"[updateBasicDetails] - Failed to update basics for app $appId belonging to org user $orgUserId")
         UpdatedFailed
     }
   }

--- a/app/services/oauth2/TokenService.scala
+++ b/app/services/oauth2/TokenService.scala
@@ -22,7 +22,7 @@ import dev.cjww.mongo.responses._
 import models.{RefreshToken, TokenExpiry, TokenRecord}
 import org.joda.time.DateTime
 import org.mongodb.scala.model.Filters.{and, equal}
-import org.mongodb.scala.model.Updates.set
+import org.mongodb.scala.model.Updates.{combine, set}
 import org.slf4j.LoggerFactory
 import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim, JwtHeader}
 import play.api.Configuration
@@ -140,7 +140,7 @@ trait TokenService {
 
   def updateTokenRecordSet(recordSetId: String, accessTokenId: String, idTokenId: String)(implicit ec: ExC): Future[MongoUpdatedResponse] = {
     val query = equal("tokenSetId", recordSetId)
-    val update = and(
+    val update = combine(
       set("accessTokenId", accessTokenId),
       set("idTokenId", idTokenId),
       set("issuedAt", new DateTime())

--- a/app/services/users/UserService.scala
+++ b/app/services/users/UserService.scala
@@ -24,7 +24,7 @@ import models._
 import org.joda.time.DateTime
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.Filters.{and, equal}
-import org.mongodb.scala.model.Updates.{set, unset}
+import org.mongodb.scala.model.Updates.{combine, set, unset}
 import org.slf4j.{Logger, LoggerFactory}
 import utils.StringUtils
 
@@ -124,7 +124,7 @@ trait UserService extends DeObfuscators with SecurityConfiguration with UserStor
 
   def updateUserEmailAddress(userId: String, emailAddress: String)(implicit ec: ExC): Future[MongoUpdatedResponse] = {
     val collection = getUserStore(userId)
-    val update: String => Bson = email => and(
+    val update: String => Bson = email => combine(
       set("email", email),
       set("emailVerified", false)
     )
@@ -141,7 +141,7 @@ trait UserService extends DeObfuscators with SecurityConfiguration with UserStor
 
   def updatePassword(userId: String, password: String, salt: String)(implicit ec: ExC): Future[MongoUpdatedResponse] = {
     val collection = getUserStore(userId)
-    val update = and(
+    val update = combine(
       set("password", password),
       set("salt", salt)
     )
@@ -159,7 +159,7 @@ trait UserService extends DeObfuscators with SecurityConfiguration with UserStor
   def updateName(userId: String, firstName: Option[String], middleName: Option[String], lastName: Option[String], nickName: Option[String])
                 (implicit ec: ExC): Future[MongoUpdatedResponse] = {
     val collection = getUserStore(userId)
-    val update = and(
+    val update = combine(
       firstName.fold(unset("profile.givenName"))(fn => set("profile.givenName", fn)),
       middleName.fold(unset("profile.middleName"))(mN => set("profile.middleName", mN)),
       lastName.fold(unset("profile.familyName"))(lN => set("profile.familyName", lN)),
@@ -224,7 +224,7 @@ trait UserService extends DeObfuscators with SecurityConfiguration with UserStor
 
   def setVerifiedPhoneNumber(userId: String, phoneNumber: String)(implicit ec: ExC): Future[MongoUpdatedResponse] = {
     val collection = getUserStore(userId)
-    val phoneNumberUpdate = and(
+    val phoneNumberUpdate = combine(
       set("digitalContact.phone.number", phoneNumber),
       set("digitalContact.phone.verified", true)
     )

--- a/app/views/client/ClientView.scala.html
+++ b/app/views/client/ClientView.scala.html
@@ -42,6 +42,40 @@
 
     <div class="card">
         <div class="card-body">
+            <h4 class="card-title default-text">Basic details</h4>
+            <form action="@uiRoutes.ClientController.updateBasicDetails(app.appId)" method="post">
+                @CSRF.formField
+
+                <div class="input-group mb-3">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text" id="basic-addon1">Name</span>
+                    </div>
+                    <input type="text" class="form-control" name="name" value="@{app.name}" placeholder="Name of the client">
+                </div>
+
+                <div class="input-group mb-3">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text" id="basic-addon1">Description</span>
+                    </div>
+                    <input type="text" class="form-control" name="desc" value="@{app.desc}" placeholder="Description of what the client does">
+                </div>
+
+                <div class="input-group mb-3">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text" id="basic-addon1">Icon Url</span>
+                    </div>
+                    <input type="text" class="form-control" name="icon-url" @if(app.iconUrl.nonEmpty) { value="@{app.iconUrl.get}" } placeholder="Url to the clients icon file">
+                </div>
+
+                <hr>
+
+                <button class="btn btn-lg btn-primary btn-block" type="submit">Update basic details</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
             <h4 class="card-title default-text">Redirects</h4>
             <form action="@uiRoutes.ClientController.updateHomeAndRedirect(app.appId)" method="post">
                 @CSRF.formField

--- a/conf/gatekeeper.routes
+++ b/conf/gatekeeper.routes
@@ -50,5 +50,6 @@ POST        /client/update/flows                    controllers.ui.ClientControl
 POST        /client/update/scopes                   controllers.ui.ClientController.updateOAuthScopes(appId)
 POST        /client/update/expiry                   controllers.ui.ClientController.updateTokenExpiry(appId)
 POST        /client/update/urls                     controllers.ui.ClientController.updateHomeAndRedirect(appId)
+POST        /client/update/basics                   controllers.ui.ClientController.updateBasicDetails(appId)
 
 GET         /assets/*file                           controllers.Assets.at(path="/public", file)

--- a/test/helpers/services/MockClientService.scala
+++ b/test/helpers/services/MockClientService.scala
@@ -16,7 +16,7 @@
 
 package helpers.services
 
-import dev.cjww.mongo.responses.MongoDeleteResponse
+import dev.cjww.mongo.responses.{MongoDeleteResponse, MongoUpdatedResponse}
 import models.{PresetService, RegisteredApplication}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{reset, when}
@@ -75,6 +75,11 @@ trait MockClientService extends MockitoSugar with BeforeAndAfterEach {
 
   def mockDeleteClient(resp: MongoDeleteResponse): OngoingStubbing[Future[MongoDeleteResponse]] = {
     when(mockClientService.deleteClient(ArgumentMatchers.any[String](), ArgumentMatchers.any[String]())(ArgumentMatchers.any()))
+      .thenReturn(Future.successful(resp))
+  }
+
+  def mockUpdateBasicDetails(resp: MongoUpdatedResponse): OngoingStubbing[Future[MongoUpdatedResponse]] = {
+    when(mockClientService.updateBasicDetails(ArgumentMatchers.any[String](), ArgumentMatchers.any[String](), ArgumentMatchers.any[String](), ArgumentMatchers.any[String](), ArgumentMatchers.any[Option[String]]())(ArgumentMatchers.any()))
       .thenReturn(Future.successful(resp))
   }
 }

--- a/test/orchestrators/ClientOrchestratorSpec.scala
+++ b/test/orchestrators/ClientOrchestratorSpec.scala
@@ -16,7 +16,7 @@
 
 package orchestrators
 
-import dev.cjww.mongo.responses.{MongoFailedDelete, MongoSuccessDelete}
+import dev.cjww.mongo.responses.{MongoFailedDelete, MongoFailedUpdate, MongoSuccessDelete, MongoSuccessUpdate}
 import dev.cjww.security.Implicits._
 import dev.cjww.security.obfuscation.Obfuscators
 import helpers.Assertions
@@ -385,6 +385,28 @@ class ClientOrchestratorSpec
 
         awaitAndAssert(testOrchestrator.getAuthorisedApp(testUser.id, testApp.appId)) {
           _ mustBe None
+        }
+      }
+    }
+  }
+
+  "updateBasicDetails" should {
+    "return a MongoSuccessUpdate" when {
+      "the apps basic details were updated" in {
+        mockUpdateBasicDetails(resp = MongoSuccessUpdate)
+
+        awaitAndAssert(testOrchestrator.updateBasicDetails("testOwner", "testAppId", "testName", "testDesc", Some("testIconUrl"))) {
+          _ mustBe BasicsUpdates
+        }
+      }
+    }
+
+    "return a MongoFailedUpdate" when {
+      "the apps basic details could not be updated" in {
+        mockUpdateBasicDetails(resp = MongoFailedUpdate)
+
+        awaitAndAssert(testOrchestrator.updateBasicDetails("testOwner", "testAppId", "testName", "testDesc", Some("testIconUrl"))) {
+          _ mustBe UpdatedFailed
         }
       }
     }

--- a/test/services/ClientServiceSpec.scala
+++ b/test/services/ClientServiceSpec.scala
@@ -262,4 +262,26 @@ class ClientServiceSpec
       }
     }
   }
+
+  "updateBasicDetails" should {
+    "return a MongoSuccessUpdate" when {
+      "the apps basic details were updated" in {
+        mockUpdateApp(resp = MongoSuccessUpdate)
+
+        awaitAndAssert(testService.updateBasicDetails("testOwner", "testAppId", "testName", "testDesc", Some("testIconUrl"))) {
+          _ mustBe MongoSuccessUpdate
+        }
+      }
+    }
+
+    "return a MongoFailedUpdate" when {
+      "the apps basic details could not be updated" in {
+        mockUpdateApp(resp = MongoFailedUpdate)
+
+        awaitAndAssert(testService.updateBasicDetails("testOwner", "testAppId", "testName", "testDesc", Some("testIconUrl"))) {
+          _ mustBe MongoFailedUpdate
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Added UI fields to update a clients name, desc and icon url 

**Bug fix**

Addressed a bug that prevented users from being able to update an app clients name, description and icon url after creating the app client. Org users can now look at registered clients and update all fields. 

Furthermore a separate bug was discovered during development relating to updating anything in the mongo database. and operators combined with set for updates no longer work. Updates are combines with sets. 

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the issue in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date