### PR TITLE
#64 Added autocomplete off to MFA form to prevent previous codes appearing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
     always {
       script {
         sh 'docker compose -f docker-compose-mongo.yml down -v'
-        sh "docker image rm cjww-development/gatekeeper:${env.TAG_NAME}"
+        sh "docker image rm cjww-development/gatekeeper:${env.TAG_NAME} || true"
       }
       cleanWs()
     }

--- a/app/views/login/MFACode.scala.html
+++ b/app/views/login/MFACode.scala.html
@@ -8,7 +8,7 @@
 @(form: Form[MFACode])(implicit rh: RequestHeader, msgs: MessagesApi, lang: Lang)
 
 @Main("Login challenge", AuthForView.isAuthenticated(rh), AuthForView.isOrgUser(rh)) {
-    <form action="@uiRoutes.LoginController.mfaSubmit()" method="post">
+    <form action="@uiRoutes.LoginController.mfaSubmit()" method="post" autocomplete="off">
         <img class="mb-4" src="@routes.Assets.at("images/logo.png")" alt="" height="72">
         <h1 id="title" class="h3 mb-3 font-weight-normal">Login challenge</h1>
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,16 +44,16 @@ lazy val microservice = Project(appName, file("."))
       "dev.cjww.libs"                %  "inbound-outbound_2.13"      % "1.0.0",
       "io.github.nremond"            %  "pbkdf2-scala_2.13"          % "0.6.5",
       "com.pauldijou"                %  "jwt-core_2.13"              % "5.0.0",
-      "com.nimbusds"                 %  "nimbus-jose-jwt"            % "9.11.1",
+      "com.nimbusds"                 %  "nimbus-jose-jwt"            % "9.23",
       "dev.samstevens.totp"          %  "totp"                       % "1.7.1",
-      "com.amazonaws"                %  "aws-java-sdk-ses"           % "1.12.24",
-      "com.amazonaws"                %  "aws-java-sdk-sns"           % "1.12.24",
-      "com.fasterxml.jackson.module" %% "jackson-module-scala"       % "2.12.4",
-      "org.mockito"                  %  "mockito-core"               % "3.11.2"      % Test,
+      "com.amazonaws"                %  "aws-java-sdk-ses"           % "1.12.241",
+      "com.amazonaws"                %  "aws-java-sdk-sns"           % "1.12.241",
+      "com.fasterxml.jackson.module" %% "jackson-module-scala"       % "2.13.3",
+      "org.mockito"                  %  "mockito-core"               % "4.6.1"       % Test,
       "org.scalatestplus"            %  "scalatestplus-mockito_2.13" % "1.0.0-M2"    % Test,
       "org.scalatestplus.play"       %  "scalatestplus-play_2.13"    % "5.1.0"       % Test,
       "org.scalatestplus.play"       %  "scalatestplus-play_2.13"    % "5.1.0"       % IntegrationTest,
-      "org.jsoup"                    % "jsoup"                       % "1.14.1"      % IntegrationTest
+      "org.jsoup"                    % "jsoup"                       % "1.15.1"      % IntegrationTest
     ),
     scalacOptions ++= Seq(
       "-unchecked",

--- a/docker-compose-mongo.yml
+++ b/docker-compose-mongo.yml
@@ -8,8 +8,8 @@ networks:
 services:
   mongo:
     image: mongo:latest
-    container_name: mongo.local
-    hostname: mongo.local
+    container_name: gatekeeper-mongo.local
+    hostname: gatekeeper-mongo.local
     ports:
       - 27017:27017
     networks:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" %  "sbt-plugin"            % "2.8.8")
+addSbtPlugin("com.typesafe.play" %  "sbt-plugin"            % "2.8.16")
 addSbtPlugin("com.typesafe.sbt"  %  "sbt-coffeescript"      % "1.0.2")
 addSbtPlugin("com.typesafe.sbt"  %  "sbt-less"              % "1.1.2")
 addSbtPlugin("com.typesafe.sbt"  %  "sbt-jshint"            % "1.0.6")


### PR DESCRIPTION
# GK #64 Prevent previous TOTP codes appearing in autocomplete dropdown

**Bug fix**

On the MFA form autocomplete was defaulting to on, this has now been disabled to prevent previous codes appearing on login.

## Checklist
* [x] I've included appropriate tests with any code I've added
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the issue in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date